### PR TITLE
添加PaddleOcrAll.BytesPerPixel，像素内存分别支持3通道BGR、4通道BGRA

### DIFF
--- a/examples/SystemDrawing.WinForms/MainForm.cs
+++ b/examples/SystemDrawing.WinForms/MainForm.cs
@@ -1,3 +1,4 @@
+using Sdcb.SimdPaddleOCR;
 using System;
 using System.Diagnostics;
 using System.Drawing;
@@ -7,7 +8,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using Sdcb.SimdPaddleOCR;
+using System.Xml.Linq;
 
 namespace SystemDrawing.WinForms;
 
@@ -70,6 +71,10 @@ internal sealed class MainForm : Form
         AddPathRow(2, "CLS 模型", _clsPath, "模型|*.onnx|所有文件|*.*", false);
         AddPathRow(3, "REC 模型", _recPath, "模型|*.onnx|所有文件|*.*", false);
         AddPathRow(4, "字典", _dictPath, "字典|*.txt|所有文件|*.*", false);
+
+        CheckBox bppCheckBox = new() { Text = "颜色通道数(默认选中为3通道BGR, 不选为4通道BGRA)", Checked = true, Size = new Size(400, 30), Anchor = AnchorStyles.Left, Margin = new Padding(0, 7, 6, 4) };
+        bppCheckBox.CheckedChanged += (_, _) => PaddleOcrAll.BytesPerPixel = bppCheckBox.Checked ? 3 : 4;
+        _paths.Controls.Add(bppCheckBox, 1, 5);
 
         TableLayoutPanel root = new() { Dock = DockStyle.Fill, Padding = new Padding(12), RowCount = 3, ColumnCount = 1 };
         root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); root.RowStyles.Add(new RowStyle(SizeType.Percent, 100)); root.RowStyles.Add(new RowStyle(SizeType.Absolute, 34));
@@ -145,15 +150,33 @@ internal sealed class MainForm : Form
         finally { _run.Enabled = _ocr is not null; _paths.Enabled = true; }
     }
 
-    private OcrResult RunPipeline(string imagePath)
+    unsafe private OcrResult RunPipeline(string imagePath)
     {
+        //改用直接访问内存，提升性能
         using Bitmap bitmap = new(imagePath);
-        byte[] bgr = ToBgr(bitmap, out int stride); PaddleOcrResult result = _ocr!.Run(bgr, bitmap.Width, bitmap.Height, stride); Bitmap annotated = new(bitmap);
-        using Graphics graphics = Graphics.FromImage(annotated); using Pen pen = new(Color.LimeGreen, 3); using Brush brush = new SolidBrush(Color.Red);
+        var w = bitmap.Width;
+        var h = bitmap.Height;
+        var stride = w * PaddleOcrAll.BytesPerPixel;
+        var data = bitmap.LockBits(
+            new Rectangle(0, 0, w, h),
+            ImageLockMode.ReadOnly,
+            PaddleOcrAll.BytesPerPixel == 4 ? PixelFormat.Format32bppArgb : PixelFormat.Format24bppRgb);
+        PaddleOcrResult result = _ocr!.Run(new ReadOnlySpan<byte>((void*)data.Scan0, stride * h), w, h, stride);
+        bitmap.UnlockBits(data);
+
+        Bitmap annotated = new(bitmap);
+        using Graphics graphics = Graphics.FromImage(annotated);
+        using Pen pen = new(Color.LimeGreen, 3);
+        using Brush brush = new SolidBrush(Color.Red);
         foreach (PaddleOcrLine line in result.Lines)
         {
-            Point[] points = [new((int)line.Box.X1, (int)line.Box.Y1), new((int)line.Box.X2, (int)line.Box.Y2), new((int)line.Box.X3, (int)line.Box.Y3), new((int)line.Box.X4, (int)line.Box.Y4)];
-            graphics.DrawPolygon(pen, points); graphics.DrawString(line.Text, Font, brush, points[0]);
+            Point[] points = [
+                new((int)line.Box.X1,(int)line.Box.Y1),
+                new((int)line.Box.X2, (int)line.Box.Y2),
+                new((int)line.Box.X3, (int)line.Box.Y3),
+                new((int)line.Box.X4, (int)line.Box.Y4)];
+            graphics.DrawPolygon(pen, points);
+            //graphics.DrawString(line.Text, Font, brush, points[0]);
         }
         return new OcrResult(string.Join(Environment.NewLine, result.Lines.Select(line => line.Text)), result.DetectedCount, annotated);
     }
@@ -162,10 +185,19 @@ internal sealed class MainForm : Form
 
     private static byte[] ToBgr(Bitmap bitmap, out int stride)
     {
-        stride = checked(bitmap.Width * 3); byte[] bgr = new byte[checked(stride * bitmap.Height)]; Rectangle rectangle = new(0, 0, bitmap.Width, bitmap.Height);
+        stride = checked(bitmap.Width * 3);
+        byte[] bgr = new byte[checked(stride * bitmap.Height)];
+        Rectangle rectangle = new(0, 0, bitmap.Width, bitmap.Height);
         BitmapData data = bitmap.LockBits(rectangle, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
-        try { for (int y = 0; y < bitmap.Height; y++) Marshal.Copy(new IntPtr(data.Scan0.ToInt64() + y * (long)data.Stride), bgr, y * stride, stride); }
-        finally { bitmap.UnlockBits(data); }
+        try
+        {
+            for (int y = 0; y < bitmap.Height; y++)
+                Marshal.Copy(new IntPtr(data.Scan0.ToInt64() + y * (long)data.Stride), bgr, y * stride, stride);
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
         return bgr;
     }
 
@@ -201,6 +233,8 @@ internal sealed class MainForm : Form
     private sealed class OcrResult
     {
         public OcrResult(string text, int count, Bitmap annotated) { Text = text; Count = count; Annotated = annotated; }
-        public string Text { get; } public int Count { get; } public Bitmap Annotated { get; }
+        public string Text { get; }
+        public int Count { get; }
+        public Bitmap Annotated { get; }
     }
 }

--- a/examples/SystemDrawing.WinForms/MainForm.resx
+++ b/examples/SystemDrawing.WinForms/MainForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/examples/SystemDrawing.WinForms/SystemDrawing.WinForms.csproj
+++ b/examples/SystemDrawing.WinForms/SystemDrawing.WinForms.csproj
@@ -10,6 +10,7 @@
     <AutoGenerateBindingRedirects Condition="'$(TargetFramework)' == 'net48'">true</AutoGenerateBindingRedirects>
     <ApplicationManifest Condition="'$(TargetFramework)' == 'net48'">app.manifest</ApplicationManifest>
     <PlatformTarget>x64</PlatformTarget>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sdcb.SimdPaddleOCR\Sdcb.SimdPaddleOCR.csproj" />

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Avx.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Avx.cs
@@ -69,7 +69,7 @@ internal static partial class Warp
         Vector256<double> wy = CubicWeightVectorAvx(ty);
         Vector256<double> wx0 = Avx2.Permute4x64(wx, 0x00), wx1 = Avx2.Permute4x64(wx, 0x55);
         Vector256<double> wx2 = Avx2.Permute4x64(wx, 0xAA), wx3 = Avx2.Permute4x64(wx, 0xFF);
-        byte* row = source + (yBase - 1) * stride + (xBase - 1) * 3;
+        byte* row = source + (yBase - 1) * stride + (xBase - 1) * PaddleOcrAll.BytesPerPixel;
         Vector256<double> acc = AccumulateRowAvx(row, wx0, wx1, wx2, wx3,
             Avx2.Permute4x64(wy, 0x00), Vector256<double>.Zero);
         acc = AccumulateRowAvx(row + stride, wx0, wx1, wx2, wx3, Avx2.Permute4x64(wy, 0x55), acc);
@@ -84,10 +84,11 @@ internal static partial class Warp
         Vector256<double> wx0, Vector256<double> wx1, Vector256<double> wx2, Vector256<double> wx3,
         Vector256<double> wy, Vector256<double> acc)
     {
+        int bpp = PaddleOcrAll.BytesPerPixel;
         acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row), wx0), wy));
-        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 3), wx1), wy));
-        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 6), wx2), wy));
-        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 9), wx3), wy));
+        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + bpp), wx1), wy));
+        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 2 * bpp), wx2), wy));
+        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 3 * bpp), wx3), wy));
         return acc;
     }
 

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Avx.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Avx.cs
@@ -69,7 +69,7 @@ internal static partial class Warp
         Vector256<double> wy = CubicWeightVectorAvx(ty);
         Vector256<double> wx0 = Avx2.Permute4x64(wx, 0x00), wx1 = Avx2.Permute4x64(wx, 0x55);
         Vector256<double> wx2 = Avx2.Permute4x64(wx, 0xAA), wx3 = Avx2.Permute4x64(wx, 0xFF);
-        byte* row = source + (yBase - 1) * stride + (xBase - 1) * PaddleOcrAll.BytesPerPixel;
+        byte* row = source + (yBase - 1) * stride + (xBase - 1) * BytesPerPixel;
         Vector256<double> acc = AccumulateRowAvx(row, wx0, wx1, wx2, wx3,
             Avx2.Permute4x64(wy, 0x00), Vector256<double>.Zero);
         acc = AccumulateRowAvx(row + stride, wx0, wx1, wx2, wx3, Avx2.Permute4x64(wy, 0x55), acc);
@@ -84,11 +84,10 @@ internal static partial class Warp
         Vector256<double> wx0, Vector256<double> wx1, Vector256<double> wx2, Vector256<double> wx3,
         Vector256<double> wy, Vector256<double> acc)
     {
-        int bpp = PaddleOcrAll.BytesPerPixel;
         acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row), wx0), wy));
-        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + bpp), wx1), wy));
-        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 2 * bpp), wx2), wy));
-        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 3 * bpp), wx3), wy));
+        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + BytesPerPixel), wx1), wy));
+        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 2 * BytesPerPixel), wx2), wy));
+        acc = Avx.Add(acc, Avx.Multiply(Avx.Multiply(LoadPixelAvx(row + 3 * BytesPerPixel), wx3), wy));
         return acc;
     }
 

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Avx512.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Avx512.cs
@@ -74,7 +74,7 @@ internal static partial class Warp
         Vector512<double> wx1 = Vector512.Create(wx.GetElement(1));
         Vector512<double> wx2 = Vector512.Create(wx.GetElement(2));
         Vector512<double> wx3 = Vector512.Create(wx.GetElement(3));
-        byte* row = source + (yBase - 1) * stride + (xBase - 1) * PaddleOcrAll.BytesPerPixel;
+        byte* row = source + (yBase - 1) * stride + (xBase - 1) * Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         Vector512<double> acc = AccumulateRowAvx512(row, wx0, wx1, wx2, wx3,
             Vector512.Create(wy.GetElement(0)), Vector512<double>.Zero);
         acc = AccumulateRowAvx512(row + stride, wx0, wx1, wx2, wx3, Vector512.Create(wy.GetElement(1)), acc);
@@ -89,7 +89,7 @@ internal static partial class Warp
         Vector512<double> wx0, Vector512<double> wx1, Vector512<double> wx2, Vector512<double> wx3,
         Vector512<double> wy, Vector512<double> acc)
     {
-        int bpp = PaddleOcrAll.BytesPerPixel;
+        int bpp = Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row), wx0), wy));
         acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row + bpp), wx1), wy));
         acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row + 2 * bpp), wx2), wy));

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Avx512.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Avx512.cs
@@ -74,7 +74,7 @@ internal static partial class Warp
         Vector512<double> wx1 = Vector512.Create(wx.GetElement(1));
         Vector512<double> wx2 = Vector512.Create(wx.GetElement(2));
         Vector512<double> wx3 = Vector512.Create(wx.GetElement(3));
-        byte* row = source + (yBase - 1) * stride + (xBase - 1) * 3;
+        byte* row = source + (yBase - 1) * stride + (xBase - 1) * PaddleOcrAll.BytesPerPixel;
         Vector512<double> acc = AccumulateRowAvx512(row, wx0, wx1, wx2, wx3,
             Vector512.Create(wy.GetElement(0)), Vector512<double>.Zero);
         acc = AccumulateRowAvx512(row + stride, wx0, wx1, wx2, wx3, Vector512.Create(wy.GetElement(1)), acc);
@@ -89,10 +89,11 @@ internal static partial class Warp
         Vector512<double> wx0, Vector512<double> wx1, Vector512<double> wx2, Vector512<double> wx3,
         Vector512<double> wy, Vector512<double> acc)
     {
+        int bpp = PaddleOcrAll.BytesPerPixel;
         acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row), wx0), wy));
-        acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row + 3), wx1), wy));
-        acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row + 6), wx2), wy));
-        acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row + 9), wx3), wy));
+        acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row + bpp), wx1), wy));
+        acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row + 2 * bpp), wx2), wy));
+        acc = Avx512F.Add(acc, Avx512F.Multiply(Avx512F.Multiply(LoadPixelAvx512(row + 3 * bpp), wx3), wy));
         return acc;
     }
 

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Scalar.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Scalar.cs
@@ -34,7 +34,7 @@ internal static partial class Warp
             throw new InvalidDataException("Invalid perspective transform.");
         int destinationX = rotateVertical ? unrotatedHeight - 1 - y : x;
         int destinationY = rotateVertical ? x : y;
-        int destination = checked((destinationY * outputWidth + destinationX) * 3);
+        int destination = checked((destinationY * outputWidth + destinationX) * PaddleOcrAll.BytesPerPixel);
         SampleCubicScalar(sourcePtr, sourceWidth, sourceHeight, sourceStride,
             sx, sy, cropPtr, destination);
     }
@@ -58,14 +58,15 @@ internal static partial class Warp
             CubicWeight(y - (yBase + 1)),
             CubicWeight(y - (yBase + 2)),
         ];
+        int bpp = PaddleOcrAll.BytesPerPixel;
         double value0 = 0, value1 = 0, value2 = 0;
         if (xBase >= 1 && xBase < width - 2 && yBase >= 1 && yBase < height - 2)
         {
             for (int ky = 0; ky < 4; ky++)
             {
                 double wy = yWeights[ky];
-                int sourceOffset = (yBase + ky - 1) * stride + (xBase - 1) * 3;
-                for (int kx = 0; kx < 4; kx++, sourceOffset += 3)
+                int sourceOffset = (yBase + ky - 1) * stride + (xBase - 1) * bpp;
+                for (int kx = 0; kx < 4; kx++, sourceOffset += bpp)
                 {
                     double wx = xWeights[kx];
                     value0 += source[sourceOffset] * wx * wy;
@@ -84,7 +85,7 @@ internal static partial class Warp
                 {
                     double wx = xWeights[kx];
                     int sx = Clamp(xBase + kx - 1, width);
-                    int sourceOffset = sy * stride + sx * 3;
+                    int sourceOffset = sy * stride + sx * bpp;
                     value0 += source[sourceOffset] * wx * wy;
                     value1 += source[sourceOffset + 1] * wx * wy;
                     value2 += source[sourceOffset + 2] * wx * wy;

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Scalar.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Scalar.cs
@@ -34,7 +34,7 @@ internal static partial class Warp
             throw new InvalidDataException("Invalid perspective transform.");
         int destinationX = rotateVertical ? unrotatedHeight - 1 - y : x;
         int destinationY = rotateVertical ? x : y;
-        int destination = checked((destinationY * outputWidth + destinationX) * PaddleOcrAll.BytesPerPixel);
+        int destination = checked((destinationY * outputWidth + destinationX) * BytesPerPixel);
         SampleCubicScalar(sourcePtr, sourceWidth, sourceHeight, sourceStride,
             sx, sy, cropPtr, destination);
     }
@@ -58,15 +58,14 @@ internal static partial class Warp
             CubicWeight(y - (yBase + 1)),
             CubicWeight(y - (yBase + 2)),
         ];
-        int bpp = PaddleOcrAll.BytesPerPixel;
         double value0 = 0, value1 = 0, value2 = 0;
         if (xBase >= 1 && xBase < width - 2 && yBase >= 1 && yBase < height - 2)
         {
             for (int ky = 0; ky < 4; ky++)
             {
                 double wy = yWeights[ky];
-                int sourceOffset = (yBase + ky - 1) * stride + (xBase - 1) * bpp;
-                for (int kx = 0; kx < 4; kx++, sourceOffset += bpp)
+                int sourceOffset = (yBase + ky - 1) * stride + (xBase - 1) * BytesPerPixel;
+                for (int kx = 0; kx < 4; kx++, sourceOffset += BytesPerPixel)
                 {
                     double wx = xWeights[kx];
                     value0 += source[sourceOffset] * wx * wy;
@@ -85,7 +84,7 @@ internal static partial class Warp
                 {
                     double wx = xWeights[kx];
                     int sx = Clamp(xBase + kx - 1, width);
-                    int sourceOffset = sy * stride + sx * bpp;
+                    int sourceOffset = sy * stride + sx * BytesPerPixel;
                     value0 += source[sourceOffset] * wx * wy;
                     value1 += source[sourceOffset + 1] * wx * wy;
                     value2 += source[sourceOffset + 2] * wx * wy;

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Vector.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Vector.cs
@@ -69,7 +69,7 @@ internal static partial class Warp
         Vector<double> wy = CubicWeightVector(new Vector<double>(y) - tap);
         Vector<double> wx0 = new(wx.GetElement(0)), wx1 = new(wx.GetElement(1));
         Vector<double> wx2 = new(wx.GetElement(2)), wx3 = new(wx.GetElement(3));
-        byte* row = source + (yBase - 1) * stride + (xBase - 1) * PaddleOcrAll.BytesPerPixel;
+        byte* row = source + (yBase - 1) * stride + (xBase - 1) * BytesPerPixel;
         Vector<double> acc = AccumulateRowVector(row, wx0, wx1, wx2, wx3,
             new Vector<double>(wy.GetElement(0)), Vector<double>.Zero);
         acc = AccumulateRowVector(row + stride, wx0, wx1, wx2, wx3, new Vector<double>(wy.GetElement(1)), acc);
@@ -84,11 +84,10 @@ internal static partial class Warp
         Vector<double> wx0, Vector<double> wx1, Vector<double> wx2, Vector<double> wx3,
         Vector<double> wy, Vector<double> acc)
     {
-        int bpp = PaddleOcrAll.BytesPerPixel;
         acc += LoadPixelVector(row) * wx0 * wy;
-        acc += LoadPixelVector(row + bpp) * wx1 * wy;
-        acc += LoadPixelVector(row + 2 * bpp) * wx2 * wy;
-        acc += LoadPixelVector(row + 3 * bpp) * wx3 * wy;
+        acc += LoadPixelVector(row + BytesPerPixel) * wx1 * wy;
+        acc += LoadPixelVector(row + 2 * BytesPerPixel) * wx2 * wy;
+        acc += LoadPixelVector(row + 3 * BytesPerPixel) * wx3 * wy;
         return acc;
     }
 

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Vector.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.Vector.cs
@@ -69,7 +69,7 @@ internal static partial class Warp
         Vector<double> wy = CubicWeightVector(new Vector<double>(y) - tap);
         Vector<double> wx0 = new(wx.GetElement(0)), wx1 = new(wx.GetElement(1));
         Vector<double> wx2 = new(wx.GetElement(2)), wx3 = new(wx.GetElement(3));
-        byte* row = source + (yBase - 1) * stride + (xBase - 1) * 3;
+        byte* row = source + (yBase - 1) * stride + (xBase - 1) * PaddleOcrAll.BytesPerPixel;
         Vector<double> acc = AccumulateRowVector(row, wx0, wx1, wx2, wx3,
             new Vector<double>(wy.GetElement(0)), Vector<double>.Zero);
         acc = AccumulateRowVector(row + stride, wx0, wx1, wx2, wx3, new Vector<double>(wy.GetElement(1)), acc);
@@ -84,10 +84,11 @@ internal static partial class Warp
         Vector<double> wx0, Vector<double> wx1, Vector<double> wx2, Vector<double> wx3,
         Vector<double> wy, Vector<double> acc)
     {
+        int bpp = PaddleOcrAll.BytesPerPixel;
         acc += LoadPixelVector(row) * wx0 * wy;
-        acc += LoadPixelVector(row + 3) * wx1 * wy;
-        acc += LoadPixelVector(row + 6) * wx2 * wy;
-        acc += LoadPixelVector(row + 9) * wx3 * wy;
+        acc += LoadPixelVector(row + bpp) * wx1 * wy;
+        acc += LoadPixelVector(row + 2 * bpp) * wx2 * wy;
+        acc += LoadPixelVector(row + 3 * bpp) * wx3 * wy;
         return acc;
     }
 

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.cs
@@ -8,13 +8,18 @@ namespace Sdcb.SimdPaddleOCR.Kernels;
 
 internal static partial class Warp
 {
+    /// <summary>
+    /// Bytes per source pixel supplied to the bitmap source buffer.
+    /// </summary>
+    internal static int BytesPerPixel = 3;
+
     [MethodImpl(MethodImplCompat.AggressiveOptimization)]
     internal static unsafe void MapRow(byte* sourcePtr, int sourceWidth, int sourceHeight,
-        int sourceStride, byte* cropPtr, int outputWidth, int unrotatedWidth, int unrotatedHeight,
-        bool rotateVertical, double a, double b, double c, double d, double e, double f,
-        double g, double h, int y, double v, ref int x)
+            int sourceStride, byte* cropPtr, int outputWidth, int unrotatedWidth, int unrotatedHeight,
+            bool rotateVertical, double a, double b, double c, double d, double e, double f,
+            double g, double h, int y, double v, ref int x)
     {
-        #if !NETSTANDARD2_0
+#if !NETSTANDARD2_0
         if (Avx512F.IsSupported && unrotatedWidth >= 8)
             MapRowAvx512(sourcePtr, sourceWidth, sourceHeight, sourceStride, cropPtr, outputWidth,
                 unrotatedWidth, unrotatedHeight, rotateVertical, a, b, c, d, e, f, g, h, y, v, ref x);
@@ -22,11 +27,11 @@ internal static partial class Warp
             MapRowAvx(sourcePtr, sourceWidth, sourceHeight, sourceStride, cropPtr, outputWidth,
                 unrotatedWidth, unrotatedHeight, rotateVertical, a, b, c, d, e, f, g, h, y, v, ref x);
         else
-        #endif
-        if (Vector.IsHardwareAccelerated && Vector<double>.Count >= 2 &&
-            unrotatedWidth >= Vector<double>.Count)
-            MapRowVector(sourcePtr, sourceWidth, sourceHeight, sourceStride, cropPtr, outputWidth,
-                unrotatedWidth, unrotatedHeight, rotateVertical, a, b, c, d, e, f, g, h, y, v, ref x);
+#endif
+            if (Vector.IsHardwareAccelerated && Vector<double>.Count >= 2 &&
+                unrotatedWidth >= Vector<double>.Count)
+                MapRowVector(sourcePtr, sourceWidth, sourceHeight, sourceStride, cropPtr, outputWidth,
+                    unrotatedWidth, unrotatedHeight, rotateVertical, a, b, c, d, e, f, g, h, y, v, ref x);
     }
 
     [MethodImpl(MethodImplCompat.AggressiveOptimization)]
@@ -36,7 +41,7 @@ internal static partial class Warp
         int xBase = (int)Math.Floor(x), yBase = (int)Math.Floor(y);
         if (xBase >= 1 && xBase < width - 3 && yBase >= 1 && yBase < height - 2)
         {
-            #if !NETSTANDARD2_0
+#if !NETSTANDARD2_0
             if (Avx512F.IsSupported)
             {
                 SampleCubicAvx512(source, stride, x, y, xBase, yBase, destination, destinationOffset);
@@ -48,12 +53,12 @@ internal static partial class Warp
                 return;
             }
             else
-            #endif
-            if (Vector.IsHardwareAccelerated && Vector<double>.Count == 4)
-            {
-                SampleCubicVector(source, stride, x, y, xBase, yBase, destination, destinationOffset);
-                return;
-            }
+#endif
+                if (Vector.IsHardwareAccelerated && Vector<double>.Count == 4)
+                {
+                    SampleCubicVector(source, stride, x, y, xBase, yBase, destination, destinationOffset);
+                    return;
+                }
         }
         SampleCubicScalar(source, width, height, stride, x, y, destination, destinationOffset);
     }
@@ -65,7 +70,7 @@ internal static partial class Warp
     {
         int destinationX = rotateVertical ? unrotatedHeight - 1 - y : x;
         int destinationY = rotateVertical ? x : y;
-        int destination = checked((destinationY * outputWidth + destinationX) * PaddleOcrAll.BytesPerPixel);
+        int destination = checked((destinationY * outputWidth + destinationX) * BytesPerPixel);
         SampleCubic(sourcePtr, sourceWidth, sourceHeight, sourceStride,
             pixelX, pixelY, cropPtr, destination);
     }

--- a/src/Sdcb.SimdPaddleOCR/Kernels/Warp.cs
+++ b/src/Sdcb.SimdPaddleOCR/Kernels/Warp.cs
@@ -65,7 +65,7 @@ internal static partial class Warp
     {
         int destinationX = rotateVertical ? unrotatedHeight - 1 - y : x;
         int destinationY = rotateVertical ? x : y;
-        int destination = checked((destinationY * outputWidth + destinationX) * 3);
+        int destination = checked((destinationY * outputWidth + destinationX) * PaddleOcrAll.BytesPerPixel);
         SampleCubic(sourcePtr, sourceWidth, sourceHeight, sourceStride,
             pixelX, pixelY, cropPtr, destination);
     }

--- a/src/Sdcb.SimdPaddleOCR/PPOCRCrop.cs
+++ b/src/Sdcb.SimdPaddleOCR/PPOCRCrop.cs
@@ -21,7 +21,7 @@ internal static class PPOCRCrop
             throw new InvalidDataException("Invalid detection quadrilateral.");
         int width = transform.RotateVertical ? transform.UnrotatedHeight : transform.UnrotatedWidth;
         int height = transform.RotateVertical ? transform.UnrotatedWidth : transform.UnrotatedHeight;
-        long bytes = checked((long)width * height * PaddleOcrAll.BytesPerPixel);
+        long bytes = checked((long)width * height * Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel);
         return (width, height, checked((int)bytes));
     }
 
@@ -82,7 +82,7 @@ internal static class PPOCRCrop
     public static unsafe void Rotate180(Span<byte> pixels, int width, int height)
     {
         int count = checked(width * height);
-        int bpp = PaddleOcrAll.BytesPerPixel;
+        int bpp = Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         fixed (byte* data = pixels)
         {
             for (int left = 0; left < count / 2; left++)
@@ -155,7 +155,7 @@ internal static class PPOCRCrop
     {
         if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
         if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
-        int bpp = PaddleOcrAll.BytesPerPixel;
+        int bpp = Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         if (stride < checked(width * bpp)) throw new ArgumentException("Source stride is too small.");
         long required = checked((long)(height - 1) * stride + width * (long)bpp);
         if (required > source.Length) throw new ArgumentException("Source buffer is too small.");

--- a/src/Sdcb.SimdPaddleOCR/PPOCRCrop.cs
+++ b/src/Sdcb.SimdPaddleOCR/PPOCRCrop.cs
@@ -21,7 +21,7 @@ internal static class PPOCRCrop
             throw new InvalidDataException("Invalid detection quadrilateral.");
         int width = transform.RotateVertical ? transform.UnrotatedHeight : transform.UnrotatedWidth;
         int height = transform.RotateVertical ? transform.UnrotatedWidth : transform.UnrotatedHeight;
-        long bytes = checked((long)width * height * 3);
+        long bytes = checked((long)width * height * PaddleOcrAll.BytesPerPixel);
         return (width, height, checked((int)bytes));
     }
 
@@ -82,15 +82,17 @@ internal static class PPOCRCrop
     public static unsafe void Rotate180(Span<byte> pixels, int width, int height)
     {
         int count = checked(width * height);
+        int bpp = PaddleOcrAll.BytesPerPixel;
         fixed (byte* data = pixels)
         {
             for (int left = 0; left < count / 2; left++)
             {
                 int right = count - 1 - left;
-                byte* l = data + left * 3, r = data + right * 3;
-                byte value = l[0]; l[0] = r[0]; r[0] = value;
-                value = l[1]; l[1] = r[1]; r[1] = value;
-                value = l[2]; l[2] = r[2]; r[2] = value;
+                byte* l = data + left * bpp, r = data + right * bpp;
+                for (int i = 0; i < bpp; i++)
+                {
+                    byte value = l[i]; l[i] = r[i]; r[i] = value;
+                }
             }
         }
     }
@@ -153,8 +155,9 @@ internal static class PPOCRCrop
     {
         if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
         if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
-        if (stride < checked(width * 3)) throw new ArgumentException("Source stride is too small.");
-        long required = checked((long)(height - 1) * stride + width * 3L);
+        int bpp = PaddleOcrAll.BytesPerPixel;
+        if (stride < checked(width * bpp)) throw new ArgumentException("Source stride is too small.");
+        long required = checked((long)(height - 1) * stride + width * (long)bpp);
         if (required > source.Length) throw new ArgumentException("Source buffer is too small.");
     }
 }

--- a/src/Sdcb.SimdPaddleOCR/PPOCRPreprocess.cs
+++ b/src/Sdcb.SimdPaddleOCR/PPOCRPreprocess.cs
@@ -191,11 +191,15 @@ internal static class PPOCRPreprocess
         int sourceY, int destinationWidth, int[] offsets, short[] coefficients, int[] destination)
     {
         byte* row = source + sourceY * sourceStride;
+        int sourceBpp = PaddleOcrAll.BytesPerPixel;
         for (int x = 0; x < destinationWidth; x++)
         {
             int sx = offsets[x], sx1 = Math.Min(sx + 1, sourceWidth - 1);
             short coefficient0 = coefficients[x * 2], coefficient1 = coefficients[x * 2 + 1];
-            int sourceOffset = sx * 3, sourceOffset1 = sx1 * 3, destinationOffset = x * 3;
+            // Source pixels are BGR (3) or BGRA (4) bytes; the intermediate
+            // horizontal row buffer always carries 3 channels per pixel so
+            // downstream NCHW packing stays 3-plane regardless of input.
+            int sourceOffset = sx * sourceBpp, sourceOffset1 = sx1 * sourceBpp, destinationOffset = x * 3;
             destination[destinationOffset] = row[sourceOffset] * coefficient0 + row[sourceOffset1] * coefficient1;
             destination[destinationOffset + 1] = row[sourceOffset + 1] * coefficient0 + row[sourceOffset1 + 1] * coefficient1;
             destination[destinationOffset + 2] = row[sourceOffset + 2] * coefficient0 + row[sourceOffset1 + 2] * coefficient1;
@@ -378,6 +382,7 @@ internal static class PPOCRPreprocess
         int resizedHeight, int outputWidth, Span<float> output)
     {
         int plane = checked(resizedHeight * outputWidth);
+        int bpp = PaddleOcrAll.BytesPerPixel;
         fixed (byte* sourcePtr = resized)
         fixed (float* outputPtr = output)
         {
@@ -385,7 +390,7 @@ internal static class PPOCRPreprocess
             {
                 for (int ox = 0; ox < resizedWidth; ox++)
                 {
-                    int sourceOffset = (oy * resizedWidth + ox) * 3;
+                    int sourceOffset = (oy * resizedWidth + ox) * bpp;
                     int destination = oy * outputWidth + ox;
                     outputPtr[destination] = RecNormalized[sourcePtr[sourceOffset]];
                     outputPtr[plane + destination] = RecNormalized[sourcePtr[sourceOffset + 1]];
@@ -404,10 +409,13 @@ internal static class PPOCRPreprocess
         int sourceHeight, int sourceStride, int destinationWidth, int destinationHeight,
         Span<byte> destination)
     {
-        int required = checked(destinationWidth * destinationHeight * 3);
+        int bpp = PaddleOcrAll.BytesPerPixel;
+        int required = checked(destinationWidth * destinationHeight * bpp);
         if (destination.Length < required) throw new ArgumentException("Destination buffer is too small.");
         int[] xOffsets = PooledArrays.Rent<int>(destinationWidth);
         short[] xCoefficients = PooledArrays.Rent<short>(checked(destinationWidth * 2));
+        // Intermediate horizontal rows always carry 3 channels per pixel so
+        // downstream NCHW packing stays 3-plane regardless of source bpp.
         int[] row0 = PooledArrays.Rent<int>(checked(destinationWidth * 3));
         int[] row1 = PooledArrays.Rent<int>(checked(destinationWidth * 3));
         try
@@ -427,11 +435,11 @@ internal static class PPOCRPreprocess
                     BuildHorizontalRow(sourcePtr, sourceStride, sourceWidth, sy1,
                         destinationWidth,
                         xOffsets, xCoefficients, row1);
-                    int destinationOffset = oy * destinationWidth * 3;
+                    int destinationOffset = oy * destinationWidth * bpp;
                     for (int ox = 0; ox < destinationWidth; ox++)
                     {
                         int rowOffset = ox * 3;
-                        int pixelOffset = destinationOffset + rowOffset;
+                        int pixelOffset = destinationOffset + ox * bpp;
                         int h0 = row0[rowOffset], h1 = row1[rowOffset];
                         int value = (((h0 >> 4) * beta0 >> 16) + ((h1 >> 4) * beta1 >> 16) + 2) >> 2;
                         destinationPtr[pixelOffset] = (byte)MathCompat.Clamp(value, 0, 255);
@@ -458,8 +466,9 @@ internal static class PPOCRPreprocess
     {
         if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
         if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
-        if (stride < checked(width * 3)) throw new ArgumentException("Source stride is too small.");
-        long required = checked((long)(height - 1) * stride + width * 3L);
+        int bpp = PaddleOcrAll.BytesPerPixel;
+        if (stride < checked(width * bpp)) throw new ArgumentException("Source stride is too small.");
+        long required = checked((long)(height - 1) * stride + width * (long)bpp);
         if (required > source.Length) throw new ArgumentException("Source buffer is too small.");
     }
 

--- a/src/Sdcb.SimdPaddleOCR/PPOCRPreprocess.cs
+++ b/src/Sdcb.SimdPaddleOCR/PPOCRPreprocess.cs
@@ -191,7 +191,7 @@ internal static class PPOCRPreprocess
         int sourceY, int destinationWidth, int[] offsets, short[] coefficients, int[] destination)
     {
         byte* row = source + sourceY * sourceStride;
-        int sourceBpp = PaddleOcrAll.BytesPerPixel;
+        int sourceBpp = Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         for (int x = 0; x < destinationWidth; x++)
         {
             int sx = offsets[x], sx1 = Math.Min(sx + 1, sourceWidth - 1);
@@ -382,7 +382,7 @@ internal static class PPOCRPreprocess
         int resizedHeight, int outputWidth, Span<float> output)
     {
         int plane = checked(resizedHeight * outputWidth);
-        int bpp = PaddleOcrAll.BytesPerPixel;
+        int bpp = Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         fixed (byte* sourcePtr = resized)
         fixed (float* outputPtr = output)
         {
@@ -409,7 +409,7 @@ internal static class PPOCRPreprocess
         int sourceHeight, int sourceStride, int destinationWidth, int destinationHeight,
         Span<byte> destination)
     {
-        int bpp = PaddleOcrAll.BytesPerPixel;
+        int bpp = Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         int required = checked(destinationWidth * destinationHeight * bpp);
         if (destination.Length < required) throw new ArgumentException("Destination buffer is too small.");
         int[] xOffsets = PooledArrays.Rent<int>(destinationWidth);
@@ -466,7 +466,7 @@ internal static class PPOCRPreprocess
     {
         if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
         if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
-        int bpp = PaddleOcrAll.BytesPerPixel;
+        int bpp = Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         if (stride < checked(width * bpp)) throw new ArgumentException("Source stride is too small.");
         long required = checked((long)(height - 1) * stride + width * (long)bpp);
         if (required > source.Length) throw new ArgumentException("Source buffer is too small.");

--- a/src/Sdcb.SimdPaddleOCR/PaddleOcrAll.cs
+++ b/src/Sdcb.SimdPaddleOCR/PaddleOcrAll.cs
@@ -23,7 +23,6 @@ public sealed class PaddleOcrAll : IDisposable
 {
     private static bool s_profileEnabled;
     private static readonly long[] s_profileTicks = new long[6];
-    private static int bytesPerPixel = 3;
 
     /// <summary>
     /// Bytes per source pixel supplied to <see cref="Run"/> and to the
@@ -39,8 +38,8 @@ public sealed class PaddleOcrAll : IDisposable
     /// <exception cref="ArgumentOutOfRangeException">Value must be 3 or 4.</exception>
     public static int BytesPerPixel
     {
-        get => bytesPerPixel;
-        set => bytesPerPixel = value is 3 or 4
+        get => Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
+        set => Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel = value is 3 or 4
             ? value
             : throw new ArgumentOutOfRangeException(nameof(value), "BytesPerPixel must be 3 or 4.");
     }
@@ -156,7 +155,7 @@ public sealed class PaddleOcrAll : IDisposable
         int sourceStride = 0)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PaddleOcrAll));
-        if (sourceStride == 0) sourceStride = checked(sourceWidth * BytesPerPixel);
+        if (sourceStride == 0) sourceStride = checked(sourceWidth * Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel);
         long stageStart = s_profileEnabled ? Stopwatch.GetTimestamp() : 0;
         PaddleOcrDetectionResult detection = _detector.Detect(source, sourceWidth, sourceHeight, sourceStride);
         if (s_profileEnabled) AddProfile(0, stageStart);

--- a/src/Sdcb.SimdPaddleOCR/PaddleOcrAll.cs
+++ b/src/Sdcb.SimdPaddleOCR/PaddleOcrAll.cs
@@ -9,8 +9,9 @@ using Sdcb.SimdPaddleOCR.ModelProvider;
 namespace Sdcb.SimdPaddleOCR;
 
 /// <summary>
-/// Complete pure managed PP-OCR pipeline. It accepts packed BGR8 memory and
-/// deliberately has no image-decoding or file-system dependency.
+/// Complete pure managed PP-OCR pipeline. It accepts packed BGR or BGRA memory
+/// (see <see cref="BytesPerPixel"/>) and deliberately has no image-decoding or
+/// file-system dependency.
 /// <para>
 /// Thread-safe: the detector, classifier and recognizer each hold one shared
 /// compiled model and pool per-call inference requests, while every run rents
@@ -22,6 +23,27 @@ public sealed class PaddleOcrAll : IDisposable
 {
     private static bool s_profileEnabled;
     private static readonly long[] s_profileTicks = new long[6];
+    private static int bytesPerPixel = 3;
+
+    /// <summary>
+    /// Bytes per source pixel supplied to <see cref="Run"/> and to the
+    /// detector/classifier/recognizer entry points. Set to <c>3</c> for packed
+    /// BGR memory (default) or <c>4</c> for packed BGRA memory. The alpha
+    /// channel is ignored throughout the pipeline; choosing <c>4</c> lets
+    /// callers hand off BGRA memory directly without an external pack step.
+    /// <para>
+    /// Configure once at startup. Mutating this property while concurrent
+    /// <see cref="Run"/> calls are in flight is not advised.
+    /// </para>
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Value must be 3 or 4.</exception>
+    public static int BytesPerPixel
+    {
+        get => bytesPerPixel;
+        set => bytesPerPixel = value is 3 or 4
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value), "BytesPerPixel must be 3 or 4.");
+    }
     private readonly PaddleOcrDetector _detector;
     private readonly PaddleOcrClassifier? _classifier;
     private readonly PaddleOcrRecognizer _recognizer;
@@ -134,7 +156,7 @@ public sealed class PaddleOcrAll : IDisposable
         int sourceStride = 0)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PaddleOcrAll));
-        if (sourceStride == 0) sourceStride = checked(sourceWidth * 3);
+        if (sourceStride == 0) sourceStride = checked(sourceWidth * BytesPerPixel);
         long stageStart = s_profileEnabled ? Stopwatch.GetTimestamp() : 0;
         PaddleOcrDetectionResult detection = _detector.Detect(source, sourceWidth, sourceHeight, sourceStride);
         if (s_profileEnabled) AddProfile(0, stageStart);

--- a/src/Sdcb.SimdPaddleOCR/PaddleOcrClassifier.cs
+++ b/src/Sdcb.SimdPaddleOCR/PaddleOcrClassifier.cs
@@ -56,7 +56,7 @@ public sealed class PaddleOcrClassifier : IDisposable
         int sourceStride = 0)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PaddleOcrClassifier));
-        if (sourceStride == 0) sourceStride = checked(sourceWidth * PaddleOcrAll.BytesPerPixel);
+        if (sourceStride == 0) sourceStride = checked(sourceWidth * Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel);
         if ((long)sourceWidth * sourceHeight > _options.MaxImagePixels)
             throw new InvalidOperationException("Source image exceeds MaxImagePixels.");
         bool profile = PipelineProfiler.Enabled;

--- a/src/Sdcb.SimdPaddleOCR/PaddleOcrClassifier.cs
+++ b/src/Sdcb.SimdPaddleOCR/PaddleOcrClassifier.cs
@@ -56,7 +56,7 @@ public sealed class PaddleOcrClassifier : IDisposable
         int sourceStride = 0)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PaddleOcrClassifier));
-        if (sourceStride == 0) sourceStride = checked(sourceWidth * 3);
+        if (sourceStride == 0) sourceStride = checked(sourceWidth * PaddleOcrAll.BytesPerPixel);
         if ((long)sourceWidth * sourceHeight > _options.MaxImagePixels)
             throw new InvalidOperationException("Source image exceeds MaxImagePixels.");
         bool profile = PipelineProfiler.Enabled;

--- a/src/Sdcb.SimdPaddleOCR/PaddleOcrDetector.cs
+++ b/src/Sdcb.SimdPaddleOCR/PaddleOcrDetector.cs
@@ -5,7 +5,8 @@ using Sdcb.SimdPaddleOCR.OnnxSharp;
 
 namespace Sdcb.SimdPaddleOCR;
 
-/// <summary>Pure managed DB detector. The caller supplies packed BGR bytes.</summary>
+/// <summary>Pure managed DB detector. The caller supplies packed BGR or BGRA
+/// bytes (see <see cref="PaddleOcrAll.BytesPerPixel"/>).</summary>
 public sealed class PaddleOcrDetector : IDisposable
 {
     private static bool s_profileEnabled;
@@ -101,7 +102,8 @@ public sealed class PaddleOcrDetector : IDisposable
         int sourceStride = 0)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PaddleOcrDetector));
-        if (sourceStride == 0) sourceStride = checked(sourceWidth * 3);
+        int bpp = PaddleOcrAll.BytesPerPixel;
+        if (sourceStride == 0) sourceStride = checked(sourceWidth * bpp);
         int originalWidth = sourceWidth, originalHeight = sourceHeight;
         if ((long)sourceWidth * sourceHeight > _options.MaxImagePixels)
             throw new InvalidOperationException("Source image exceeds MaxImagePixels.");
@@ -111,18 +113,18 @@ public sealed class PaddleOcrDetector : IDisposable
         {
             int paddedWidth = Math.Max(32, sourceWidth);
             int paddedHeight = Math.Max(32, sourceHeight);
-            paddedSource = PooledArrays.Rent<byte>(checked(paddedWidth * paddedHeight * 3));
-            Span<byte> padded = paddedSource.AsSpan(0, checked(paddedWidth * paddedHeight * 3));
+            paddedSource = PooledArrays.Rent<byte>(checked(paddedWidth * paddedHeight * bpp));
+            Span<byte> padded = paddedSource.AsSpan(0, checked(paddedWidth * paddedHeight * bpp));
             padded.Clear();
             for (int y = 0; y < sourceHeight; y++)
             {
-                source.Slice(y * sourceStride, checked(sourceWidth * 3))
-                    .CopyTo(padded.Slice(y * paddedWidth * 3, checked(sourceWidth * 3)));
+                source.Slice(y * sourceStride, checked(sourceWidth * bpp))
+                    .CopyTo(padded.Slice(y * paddedWidth * bpp, checked(sourceWidth * bpp)));
             }
             source = padded;
             sourceWidth = paddedWidth;
             sourceHeight = paddedHeight;
-            sourceStride = checked(paddedWidth * 3);
+            sourceStride = checked(paddedWidth * bpp);
         }
 
         try

--- a/src/Sdcb.SimdPaddleOCR/PaddleOcrDetector.cs
+++ b/src/Sdcb.SimdPaddleOCR/PaddleOcrDetector.cs
@@ -6,7 +6,7 @@ using Sdcb.SimdPaddleOCR.OnnxSharp;
 namespace Sdcb.SimdPaddleOCR;
 
 /// <summary>Pure managed DB detector. The caller supplies packed BGR or BGRA
-/// bytes (see <see cref="PaddleOcrAll.BytesPerPixel"/>).</summary>
+/// bytes (see <see cref="Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel"/>).</summary>
 public sealed class PaddleOcrDetector : IDisposable
 {
     private static bool s_profileEnabled;
@@ -102,7 +102,7 @@ public sealed class PaddleOcrDetector : IDisposable
         int sourceStride = 0)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PaddleOcrDetector));
-        int bpp = PaddleOcrAll.BytesPerPixel;
+        int bpp = Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel;
         if (sourceStride == 0) sourceStride = checked(sourceWidth * bpp);
         int originalWidth = sourceWidth, originalHeight = sourceHeight;
         if ((long)sourceWidth * sourceHeight > _options.MaxImagePixels)

--- a/src/Sdcb.SimdPaddleOCR/PaddleOcrRecognizer.cs
+++ b/src/Sdcb.SimdPaddleOCR/PaddleOcrRecognizer.cs
@@ -7,7 +7,7 @@ using Sdcb.SimdPaddleOCR.Kernels;
 namespace Sdcb.SimdPaddleOCR;
 
 /// <summary>Pure managed PP-OCR CTC recognizer accepting BGR or BGRA crop
-/// memory (see <see cref="PaddleOcrAll.BytesPerPixel"/>).</summary>
+/// memory (see <see cref="Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel"/>).</summary>
 public sealed class PaddleOcrRecognizer : IDisposable
 {
     private readonly Model _model;
@@ -128,7 +128,7 @@ public sealed class PaddleOcrRecognizer : IDisposable
         int sourceStride = 0)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PaddleOcrRecognizer));
-        if (sourceStride == 0) sourceStride = checked(sourceWidth * PaddleOcrAll.BytesPerPixel);
+        if (sourceStride == 0) sourceStride = checked(sourceWidth * Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel);
         if ((long)sourceWidth * sourceHeight > _options.MaxImagePixels)
             throw new InvalidOperationException("Source image exceeds MaxImagePixels.");
         bool profile = PipelineProfiler.Enabled;
@@ -263,7 +263,7 @@ public sealed class PaddleOcrRecognizer : IDisposable
                     throw new InvalidOperationException("Source image exceeds MaxImagePixels.");
                 resizedWidths[k] = PPOCRPreprocess.RecBgrToNchw(
                     cropBuffer.AsSpan(offsets[line], cropBytes[line]), sourceWidth, sourceHeight,
-                    checked(sourceWidth * PaddleOcrAll.BytesPerPixel), targetWidth,
+                    checked(sourceWidth * Sdcb.SimdPaddleOCR.Kernels.Warp.BytesPerPixel), targetWidth,
                     input.Slice(k * sampleLength, sampleLength), session.ResizeWorkspace);
             }
             if (profile) PipelineProfiler.Add(PipelineProfiler.RecPreprocess, started);

--- a/src/Sdcb.SimdPaddleOCR/PaddleOcrRecognizer.cs
+++ b/src/Sdcb.SimdPaddleOCR/PaddleOcrRecognizer.cs
@@ -6,7 +6,8 @@ using Sdcb.SimdPaddleOCR.Kernels;
 
 namespace Sdcb.SimdPaddleOCR;
 
-/// <summary>Pure managed PP-OCR CTC recognizer accepting BGR crop memory.</summary>
+/// <summary>Pure managed PP-OCR CTC recognizer accepting BGR or BGRA crop
+/// memory (see <see cref="PaddleOcrAll.BytesPerPixel"/>).</summary>
 public sealed class PaddleOcrRecognizer : IDisposable
 {
     private readonly Model _model;
@@ -127,7 +128,7 @@ public sealed class PaddleOcrRecognizer : IDisposable
         int sourceStride = 0)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PaddleOcrRecognizer));
-        if (sourceStride == 0) sourceStride = checked(sourceWidth * 3);
+        if (sourceStride == 0) sourceStride = checked(sourceWidth * PaddleOcrAll.BytesPerPixel);
         if ((long)sourceWidth * sourceHeight > _options.MaxImagePixels)
             throw new InvalidOperationException("Source image exceeds MaxImagePixels.");
         bool profile = PipelineProfiler.Enabled;
@@ -262,7 +263,7 @@ public sealed class PaddleOcrRecognizer : IDisposable
                     throw new InvalidOperationException("Source image exceeds MaxImagePixels.");
                 resizedWidths[k] = PPOCRPreprocess.RecBgrToNchw(
                     cropBuffer.AsSpan(offsets[line], cropBytes[line]), sourceWidth, sourceHeight,
-                    checked(sourceWidth * 3), targetWidth,
+                    checked(sourceWidth * PaddleOcrAll.BytesPerPixel), targetWidth,
                     input.Slice(k * sampleLength, sampleLength), session.ResizeWorkspace);
             }
             if (profile) PipelineProfiler.Add(PipelineProfiler.RecPreprocess, started);


### PR DESCRIPTION
# 修改内容
1. 在 PaddleOcrAll.cs 中添加了静态属性 BytesPerPixel（默认 3，赋值时校验必须为 3 或 4），并将项目中所有与"输入像素字节"相关的硬编码进行替换，验证测试通过。
2. 优化WinForms RunPipline，改用直接访问内存，提升性能。
# 修改说明
1. 源/crop 像素始终按 PixelBytesNum 字节布局（BGR=3 或 BGRA=4）。
2. 中间 int 行缓冲 Row0/Row1 仍按 3 通道/像素存（ResizeWorkspace.Ensure 不变），因为下游 NCHW 永远是 3 平面。
3. ONNX 模型输入永远是 3 通道 NCHW（batch*3*48*width 不变）。
4. 4 字节模式下 crop 中的 A 字节为未初始化垃圾，下游预处理只读 BGR 三字节，不影响识别结果。
5. AVX/AVX512 的 LoadPixelAvx* 用 Sse41.ConvertToVector128Int32 读 4 字节零扩展为 4 个 int32，对 3 字节 BGR（第 4 字节是下个像素 B，被忽略）和 4 字节 BGRA（第 4 字节是 A，被忽略）都自动正确，只换了像素间距。
# 验证结果
1. dotnet build 库（net10.0 + netstandard2.0）：0 警告 0 错误；
2. 单元测试项目构建并通过 26/26 测试；
3. Bench/TestReport/ImageSharp.AspNetCore 示例全部构建成功；
4. 手工测试WinForms示例，3/4通道均成功。
<img width="1167" height="737" alt="image" src="https://github.com/user-attachments/assets/ec28432f-2a6b-4e99-8014-55df7f29302d" />
